### PR TITLE
Premerge https://github.com/paritytech/substrate/pull/10498

### DIFF
--- a/client/consensus/manual-seal/src/seal_block.rs
+++ b/client/consensus/manual-seal/src/seal_block.rs
@@ -153,9 +153,14 @@ pub async fn seal_block<B, BI, SC, C, E, TP, CIDP>(
 			digest_provider.append_block_import(&parent, &mut params, &inherent_data)?;
 		}
 
+		// Make sure we return the same post-hash that will be calculated when importing the block
+		// This is important in case the digest_provider added any signature, seal, ect.
+		let mut post_header = header.clone();
+		post_header.digest_mut().logs.extend(params.post_digests.iter().cloned());
+
 		match block_import.import_block(params, HashMap::new()).await? {
 			ImportResult::Imported(aux) =>
-				Ok(CreatedBlock { hash: <B as BlockT>::Header::hash(&header), aux }),
+				Ok(CreatedBlock { hash: <B as BlockT>::Header::hash(&post_header), aux }),
 			other => Err(other.into()),
 		}
 	};


### PR DESCRIPTION
This PR brings the changes from https://github.com/paritytech/substrate/pull/10498 into moonbeam's hotfix branch. This hotfix can be dropped once the upstream fix is included.

If this hotfix is accidentally dropped, many TS tests will fail with `Error: Unable to retrieve header and parent from supplied hash`