### PR TITLE
Pass signature as &[u8] to avoid triggering From::from conversion

### DIFF
--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -755,6 +755,8 @@ pub trait Crypto {
 			return false
 		};
 
+		// We pass sig.0.as_ref() to make sure we pass &[u8], and not a [u8;64]- The latter
+		// would generate a panic
 		let sig = if let Ok(s) = ed25519_dalek::Signature::try_from(sig.0.as_ref()) {
 			s
 		} else {

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -755,8 +755,11 @@ pub trait Crypto {
 			return false
 		};
 
-		let sig =
-			if let Ok(s) = ed25519_dalek::Signature::try_from(sig.0) { s } else { return false };
+		let sig = if let Ok(s) = ed25519_dalek::Signature::try_from(sig.0.as_ref()) {
+			s
+		} else {
+			return false
+		};
 
 		public_key.verify(msg, &sig).is_ok()
 	}


### PR DESCRIPTION
This fixes a behavior bug introduced in https://github.com/PureStake/substrate/commit/ec0de096ef6a147f4065b1ccab0f49d8dfa690e2 where the signature was being passed as `[u8; 64]` triggering a `From::from` conversion https://github.com/RustCrypto/signatures/blob/d610ad50d3f7dac0bad9e647231bf03aabab3078/ed25519/src/lib.rs#L372 as the impl is also auto-implemented for `TryFrom`.

Related issue https://github.com/RustCrypto/signatures/issues/563