### PR TITLE
ensure tx inclusion can't reach proof size limit

### DIFF
--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -476,12 +476,12 @@ impl BenchDb {
 		let mut block = client.new_block(Default::default()).expect("Block creation failed");
 
 		for extrinsic in self.generate_inherents(&client) {
-			block.push(extrinsic).expect("Push inherent failed");
+			block.push(extrinsic, None).expect("Push inherent failed");
 		}
 
 		let start = std::time::Instant::now();
 		for opaque in self.block_content(content, &client) {
-			match block.push(opaque) {
+			match block.push(opaque, None) {
 				Err(sp_blockchain::Error::ApplyExtrinsicFailed(
 					sp_blockchain::ApplyExtrinsicFailed::Validity(e),
 				)) if e.exhausted_resources() => break,

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -367,7 +367,7 @@ where
 		};
 
 		for inherent in inherents {
-			match block_builder.push(inherent, ensure_block_limit) {
+			match block_builder.push(inherent, None) {
 				Err(ApplyExtrinsicFailed(Validity(e))) if e.exhausted_resources() => {
 					warn!("⚠️  Dropping non-mandatory inherent from overweight block.")
 				},

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -358,8 +358,16 @@ where
 			);
 		});
 
+		let block_size_limit = block_size_limit.unwrap_or(self.default_block_size_limit);
+
+		let ensure_block_limit = if self.include_proof_in_block_size_estimation {
+			Some((true, block_size_limit))
+		} else {
+			None
+		};
+
 		for inherent in inherents {
-			match block_builder.push(inherent) {
+			match block_builder.push(inherent, ensure_block_limit) {
 				Err(ApplyExtrinsicFailed(Validity(e))) if e.exhausted_resources() => {
 					warn!("⚠️  Dropping non-mandatory inherent from overweight block.")
 				},
@@ -402,8 +410,6 @@ where
 				self.transaction_pool.ready()
 			},
 		};
-
-		let block_size_limit = block_size_limit.unwrap_or(self.default_block_size_limit);
 
 		debug!("Attempting to push transactions from the pool.");
 		debug!("Pool status: {:?}", self.transaction_pool.status());
@@ -454,7 +460,11 @@ where
 			}
 
 			trace!("[{:?}] Pushing to the block.", pending_tx_hash);
-			match sc_block_builder::BlockBuilder::push(&mut block_builder, pending_tx_data) {
+			match sc_block_builder::BlockBuilder::push(
+				&mut block_builder,
+				pending_tx_data,
+				ensure_block_limit,
+			) {
 				Ok(()) => {
 					transaction_pushed = true;
 					debug!("[{:?}] Pushed to the block.", pending_tx_hash);

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -481,7 +481,7 @@ where
 						amount: 1,
 						nonce,
 					};
-					builder.push(transfer.into_signed_tx()).unwrap();
+					builder.push(transfer.into_signed_tx(), None).unwrap();
 					nonce += 1;
 					builder.build().unwrap().block
 				},
@@ -509,7 +509,9 @@ where
 		new_authorities: Vec<AuthorityId>,
 	) -> Vec<H256> {
 		self.generate_blocks(1, BlockOrigin::File, |mut builder| {
-			builder.push(Extrinsic::AuthoritiesChange(new_authorities.clone())).unwrap();
+			builder
+				.push(Extrinsic::AuthoritiesChange(new_authorities.clone()), None)
+				.unwrap();
 			builder.build().unwrap().block
 		})
 	}

--- a/test-utils/runtime/client/src/block_builder_ext.rs
+++ b/test-utils/runtime/client/src/block_builder_ext.rs
@@ -52,7 +52,7 @@ where
 		&mut self,
 		transfer: substrate_test_runtime::Transfer,
 	) -> Result<(), sp_blockchain::Error> {
-		self.push(transfer.into_signed_tx())
+		self.push(transfer.into_signed_tx(), None)
 	}
 
 	fn push_storage_change(
@@ -60,6 +60,6 @@ where
 		key: Vec<u8>,
 		value: Option<Vec<u8>>,
 	) -> Result<(), sp_blockchain::Error> {
-		self.push(substrate_test_runtime::Extrinsic::StorageChange(key, value))
+		self.push(substrate_test_runtime::Extrinsic::StorageChange(key, value), None)
 	}
 }

--- a/utils/frame/benchmarking-cli/src/extrinsic/bench.rs
+++ b/utils/frame/benchmarking-cli/src/extrinsic/bench.rs
@@ -131,7 +131,7 @@ where
 		// Create and insert the inherents.
 		let inherents = builder.create_inherents(self.inherent_data.clone())?;
 		for inherent in inherents {
-			builder.push(inherent)?;
+			builder.push(inherent, None)?;
 		}
 
 		// Return early if `ext_builder` is `None`.
@@ -146,7 +146,7 @@ where
 		let mut num_ext = 0;
 		for nonce in 0..self.max_ext_per_block() {
 			let ext = ext_builder.build(nonce)?;
-			match builder.push(ext.clone()) {
+			match builder.push(ext.clone(), None) {
 				Ok(()) => {},
 				Err(ApplyExtrinsicFailed(Validity(TransactionValidityError::Invalid(
 					InvalidTransaction::ExhaustsResources,


### PR DESCRIPTION
Modify the substrate `BlockBuilder::push` function to allow to add an additional check to ensure that the result of the execution of a transaction does not exceed the maximum size of the block. If the check fail, all changes produced by the execution of the transaction are rollback and the transaction is **not included in the block**.

Parity could refuse to integrate this change upstream arguing that this additional check is not necessary if the proof size weight hint is correctly configured for all runtime calls (what we can't do with ethereum transactions).
It might be necessary to make this check optional at a higher level so that it can be accepted upstream.
