### PR TITLE
Fix the wasm substitute caching bug

### DIFF
--- a/client/service/src/client/wasm_substitutes.rs
+++ b/client/service/src/client/wasm_substitutes.rs
@@ -123,10 +123,13 @@ where
 		let substitutes = substitutes
 			.into_iter()
 			.map(|(block_number, code)| {
+				let mut hasher = DefaultHasher::new();
+				hasher.write(&code);
+				let hash = hasher.finish().to_ne_bytes().to_vec();
 				let runtime_code = RuntimeCode {
 					code_fetcher: &WrappedRuntimeCode((&code).into()),
 					heap_pages: None,
-					hash: Vec::new(),
+					hash,
 				};
 				let version = Self::runtime_version(&executor, &runtime_code)?;
 				let spec_version = version.spec_version;

--- a/client/service/src/client/wasm_substitutes.rs
+++ b/client/service/src/client/wasm_substitutes.rs
@@ -123,13 +123,10 @@ where
 		let substitutes = substitutes
 			.into_iter()
 			.map(|(block_number, code)| {
-				let mut hasher = DefaultHasher::new();
-				hasher.write(&code);
-				let hash = hasher.finish().to_ne_bytes().to_vec();
 				let runtime_code = RuntimeCode {
 					code_fetcher: &WrappedRuntimeCode((&code).into()),
 					heap_pages: None,
-					hash,
+					hash: make_hash(&code),
 				};
 				let version = Self::runtime_version(&executor, &runtime_code)?;
 				let spec_version = version.spec_version;


### PR DESCRIPTION
Fix the wasm substitute caching bug.

When there exist multiple code substitutes in the spec, the used to keep only one. The current solution fixes this bug by creating a unique hash for each wasm blob.
